### PR TITLE
Replace the URL to DNAstack's decommissioned or soon-to-be-decommissioned data connect services

### DIFF
--- a/presenter/completed/2-3a Finding files-completed.ipynb
+++ b/presenter/completed/2-3a Finding files-completed.ipynb
@@ -38,7 +38,7 @@
    "outputs": [],
    "source": [
     "from fasp.search import DataConnectClient\n",
-    "searchClient = DataConnectClient('https://data.publisher.dnastack.com/data-connect/')"
+    "searchClient = DataConnectClient('https://publisher-data.publisher.dnastack.com/data-connect/')"
    ]
   },
   {

--- a/presenter/completed/2-3a Finding files-completed.ipynb
+++ b/presenter/completed/2-3a Finding files-completed.ipynb
@@ -184,8 +184,8 @@
     "from fasp.search import DataConnectClient\n",
     "\n",
     "query = '''SELECT f.sample_name, drs_id bam_drs_id, acc\n",
-    "FROM collections.public_datasets.ssd_drs s \n",
-    "join collections.public_datasets.sra_drs_files f on f.sample_name = s.su_submitter_id \n",
+    "FROM collections.public_datasets.onek_genomes_ssd_drs s \n",
+    "join collections.public_datasets.onek_genomes_sra_drs_files f on f.sample_name = s.su_submitter_id \n",
     "where filetype = 'bam' and mapped = 'mapped' \n",
     "and sequencing_type ='exome' and  population = 'JPT' '''\n",
     "\n",
@@ -294,8 +294,8 @@
    ],
    "source": [
     "family_query = '''SELECT f.sample_name, relationship, drs_id bam_drs_id, acc\n",
-    "FROM collections.public_datasets.thousand_genomes_meta s \n",
-    "join collections.public_datasets.sra_drs_files f on f.sample_name = s.sample \n",
+    "FROM collections.public_datasets.onek_genomes_thousand_genomes_meta s \n",
+    "join collections.public_datasets.onek_genomes_sra_drs_files f on f.sample_name = s.sample \n",
     "where filetype = 'bam' and mapped = 'mapped' \n",
     "and sequencing_type ='exome' and  family_id = '1447' '''\n",
     "\n",
@@ -439,7 +439,7 @@
     }
    ],
    "source": [
-    "schema1 = searchClient.list_table_info('collections.public_datasets.sra_drs_files', verbose=True)"
+    "schema1 = searchClient.list_table_info('collections.public_datasets.onek_genomes_sra_drs_files', verbose=True)"
    ]
   },
   {
@@ -655,7 +655,7 @@
     }
    ],
    "source": [
-    "schema2 = searchClient.list_table_info('collections.public_datasets.ssd_drs', verbose=True)"
+    "schema2 = searchClient.list_table_info('collections.public_datasets.onek_genomes_ssd_drs', verbose=True)"
    ]
   },
   {
@@ -846,8 +846,8 @@
    ],
    "source": [
     "query = f'''SELECT f.sample_name, drs_id bam_drs_id, acc, filename\n",
-    "FROM collections.public_datasets.ssd_drs s \n",
-    "join collections.public_datasets.sra_drs_files f on f.sample_name = s.su_submitter_id \n",
+    "FROM collections.public_datasets.onek_genomes_ssd_drs s \n",
+    "join collections.public_datasets.onek_genomes_sra_drs_files f on f.sample_name = s.su_submitter_id \n",
     "\n",
     "where filetype = 'bam' and mapped = '{mapping_type}' \n",
     "and sequencing_type ='exome' and  population = '{population_code}'\n",
@@ -968,7 +968,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -982,7 +982,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.6 (default, Oct 18 2022, 12:41:40) \n[Clang 14.0.0 (clang-1400.0.29.202)]"
+   "version": "3.9.6"
   },
   "vscode": {
    "interpreter": {

--- a/presenter/completed/2-3a Finding files-completed.ipynb
+++ b/presenter/completed/2-3a Finding files-completed.ipynb
@@ -38,7 +38,7 @@
    "outputs": [],
    "source": [
     "from fasp.search import DataConnectClient\n",
-    "searchClient = DataConnectClient('https://data-connect-trino-public.prod.dnastack.com/')"
+    "searchClient = DataConnectClient('https://data.publisher.dnastack.com/data-connect/')"
    ]
   },
   {
@@ -184,8 +184,8 @@
     "from fasp.search import DataConnectClient\n",
     "\n",
     "query = '''SELECT f.sample_name, drs_id bam_drs_id, acc\n",
-    "FROM thousand_genomes.onek_genomes.ssd_drs s \n",
-    "join thousand_genomes.onek_genomes.sra_drs_files f on f.sample_name = s.su_submitter_id \n",
+    "FROM collections.public_datasets.ssd_drs s \n",
+    "join collections.public_datasets.sra_drs_files f on f.sample_name = s.su_submitter_id \n",
     "where filetype = 'bam' and mapped = 'mapped' \n",
     "and sequencing_type ='exome' and  population = 'JPT' '''\n",
     "\n",
@@ -294,8 +294,8 @@
    ],
    "source": [
     "family_query = '''SELECT f.sample_name, relationship, drs_id bam_drs_id, acc\n",
-    "FROM thousand_genomes.onek_genomes.thousand_genomes_meta s \n",
-    "join thousand_genomes.onek_genomes.sra_drs_files f on f.sample_name = s.sample \n",
+    "FROM collections.public_datasets.thousand_genomes_meta s \n",
+    "join collections.public_datasets.sra_drs_files f on f.sample_name = s.sample \n",
     "where filetype = 'bam' and mapped = 'mapped' \n",
     "and sequencing_type ='exome' and  family_id = '1447' '''\n",
     "\n",
@@ -337,7 +337,7 @@
     }
    ],
    "source": [
-    "table_list = searchClient.list_catalog('thousand_genomes')"
+    "table_list = searchClient.list_catalog('collections')  # This will list all accessible tables."
    ]
   },
   {
@@ -439,7 +439,7 @@
     }
    ],
    "source": [
-    "schema1 = searchClient.list_table_info('thousand_genomes.onek_genomes.sra_drs_files', verbose=True)"
+    "schema1 = searchClient.list_table_info('collections.public_datasets.sra_drs_files', verbose=True)"
    ]
   },
   {
@@ -655,7 +655,7 @@
     }
    ],
    "source": [
-    "schema2 = searchClient.list_table_info('thousand_genomes.onek_genomes.ssd_drs', verbose=True)"
+    "schema2 = searchClient.list_table_info('collections.public_datasets.ssd_drs', verbose=True)"
    ]
   },
   {
@@ -846,8 +846,8 @@
    ],
    "source": [
     "query = f'''SELECT f.sample_name, drs_id bam_drs_id, acc, filename\n",
-    "FROM thousand_genomes.onek_genomes.ssd_drs s \n",
-    "join thousand_genomes.onek_genomes.sra_drs_files f on f.sample_name = s.su_submitter_id \n",
+    "FROM collections.public_datasets.ssd_drs s \n",
+    "join collections.public_datasets.sra_drs_files f on f.sample_name = s.su_submitter_id \n",
     "\n",
     "where filetype = 'bam' and mapped = '{mapping_type}' \n",
     "and sequencing_type ='exome' and  population = '{population_code}'\n",
@@ -968,7 +968,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -982,7 +982,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.9.6 (default, Oct 18 2022, 12:41:40) \n[Clang 14.0.0 (clang-1400.0.29.202)]"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "31f2aee4e71d21fbe5cf8b01ff0e069b9275f58929596ceb00d14d90e3e16cd6"
+   }
   }
  },
  "nbformat": 4,

--- a/presenter/completed/2-3b Finding files via user interface-completed.ipynb
+++ b/presenter/completed/2-3b Finding files via user interface-completed.ipynb
@@ -60,8 +60,8 @@
    ],
    "source": [
     "query_all = '''SELECT f.sample_name, drs_id bam_drs_id, acc, population, mapped, sequencing_type\n",
-    "FROM collections.public_datasets.ssd_drs s \n",
-    "join collections.public_datasets.sra_drs_files f on f.sample_name = s.su_submitter_id \n",
+    "FROM collections.public_datasets.onek_genomes_ssd_drs s \n",
+    "join collections.public_datasets.onek_genomes_sra_drs_files f on f.sample_name = s.su_submitter_id \n",
     "where filetype = 'bam'   \n",
     " '''\n",
     "int_df = searchClient.run_query(query_all, returnType='dataframe')\n",
@@ -176,7 +176,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -190,7 +190,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.6 (default, Oct 18 2022, 12:41:40) \n[Clang 14.0.0 (clang-1400.0.29.202)]"
+   "version": "3.9.6"
   },
   "vscode": {
    "interpreter": {

--- a/presenter/completed/2-3b Finding files via user interface-completed.ipynb
+++ b/presenter/completed/2-3b Finding files via user interface-completed.ipynb
@@ -33,7 +33,7 @@
    "outputs": [],
    "source": [
     "from fasp.search import DataConnectClient\n",
-    "searchClient = DataConnectClient('https://data.publisher.dnastack.com/data-connect/')"
+    "searchClient = DataConnectClient('https://publisher-data.publisher.dnastack.com/data-connect/')"
    ]
   },
   {

--- a/presenter/completed/2-3b Finding files via user interface-completed.ipynb
+++ b/presenter/completed/2-3b Finding files via user interface-completed.ipynb
@@ -33,7 +33,7 @@
    "outputs": [],
    "source": [
     "from fasp.search import DataConnectClient\n",
-    "searchClient = DataConnectClient('https://data-connect-trino-public.prod.dnastack.com/')"
+    "searchClient = DataConnectClient('https://data.publisher.dnastack.com/data-connect/')"
    ]
   },
   {
@@ -60,8 +60,8 @@
    ],
    "source": [
     "query_all = '''SELECT f.sample_name, drs_id bam_drs_id, acc, population, mapped, sequencing_type\n",
-    "FROM thousand_genomes.onek_genomes.ssd_drs s \n",
-    "join thousand_genomes.onek_genomes.sra_drs_files f on f.sample_name = s.su_submitter_id \n",
+    "FROM collections.public_datasets.ssd_drs s \n",
+    "join collections.public_datasets.sra_drs_files f on f.sample_name = s.su_submitter_id \n",
     "where filetype = 'bam'   \n",
     " '''\n",
     "int_df = searchClient.run_query(query_all, returnType='dataframe')\n",
@@ -176,7 +176,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -190,7 +190,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.9.6 (default, Oct 18 2022, 12:41:40) \n[Clang 14.0.0 (clang-1400.0.29.202)]"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "31f2aee4e71d21fbe5cf8b01ff0e069b9275f58929596ceb00d14d90e3e16cd6"
+   }
   }
  },
  "nbformat": 4,

--- a/presenter/completed/3-1 Putting it all together-completed.ipynb
+++ b/presenter/completed/3-1 Putting it all together-completed.ipynb
@@ -98,7 +98,7 @@
    "source": [
     "from fasp.search import DataConnectClient\n",
     "\n",
-    "searchClient = DataConnectClient('https://data.publisher.dnastack.com/data-connect/')\n",
+    "searchClient = DataConnectClient('https://publisher-data.publisher.dnastack.com/data-connect/')\n",
     "\n",
     "query = '''SELECT f.sample_name, drs_id bam_drs_id, acc,\n",
     "population, annotated_sex\n",

--- a/presenter/completed/3-1 Putting it all together-completed.ipynb
+++ b/presenter/completed/3-1 Putting it all together-completed.ipynb
@@ -98,12 +98,12 @@
    "source": [
     "from fasp.search import DataConnectClient\n",
     "\n",
-    "searchClient = DataConnectClient('https://ga4gh-search-adapter-presto-public.prod.dnastack.com/')\n",
+    "searchClient = DataConnectClient('https://data.publisher.dnastack.com/data-connect/')\n",
     "\n",
     "query = '''SELECT f.sample_name, drs_id bam_drs_id, acc,\n",
     "population, annotated_sex\n",
-    "FROM thousand_genomes.onek_genomes.ssd_drs s \n",
-    "join thousand_genomes.onek_genomes.sra_drs_files f on f.sample_name = s.su_submitter_id \n",
+    "FROM collections.public_datasets.ssd_drs s \n",
+    "join collections.public_datasets.sra_drs_files f on f.sample_name = s.su_submitter_id \n",
     "where filetype = 'bam' and mapped = 'mapped' \n",
     "and sequencing_type ='exome' and  population = 'PUR' LIMIT 3'''\n",
     "\n",
@@ -566,7 +566,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -580,7 +580,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.9.6 (default, Oct 18 2022, 12:41:40) \n[Clang 14.0.0 (clang-1400.0.29.202)]"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "31f2aee4e71d21fbe5cf8b01ff0e069b9275f58929596ceb00d14d90e3e16cd6"
+   }
   }
  },
  "nbformat": 4,

--- a/presenter/completed/3-1 Putting it all together-completed.ipynb
+++ b/presenter/completed/3-1 Putting it all together-completed.ipynb
@@ -102,8 +102,8 @@
     "\n",
     "query = '''SELECT f.sample_name, drs_id bam_drs_id, acc,\n",
     "population, annotated_sex\n",
-    "FROM collections.public_datasets.ssd_drs s \n",
-    "join collections.public_datasets.sra_drs_files f on f.sample_name = s.su_submitter_id \n",
+    "FROM collections.public_datasets.onek_genomes_ssd_drs s \n",
+    "join collections.public_datasets.onek_genomes_sra_drs_files f on f.sample_name = s.su_submitter_id \n",
     "where filetype = 'bam' and mapped = 'mapped' \n",
     "and sequencing_type ='exome' and  population = 'PUR' LIMIT 3'''\n",
     "\n",
@@ -566,7 +566,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -580,7 +580,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.6 (default, Oct 18 2022, 12:41:40) \n[Clang 14.0.0 (clang-1400.0.29.202)]"
+   "version": "3.9.6"
   },
   "vscode": {
    "interpreter": {

--- a/sessions/session2/2-3a Finding files.ipynb
+++ b/sessions/session2/2-3a Finding files.ipynb
@@ -38,7 +38,7 @@
    "outputs": [],
    "source": [
     "from fasp.search import DataConnectClient\n",
-    "searchClient = DataConnectClient('https://data.publisher.dnastack.com/data-connect/')"
+    "searchClient = DataConnectClient('https://publisher-data.publisher.dnastack.com/data-connect/')"
    ]
   },
   {

--- a/sessions/session2/2-3a Finding files.ipynb
+++ b/sessions/session2/2-3a Finding files.ipynb
@@ -50,8 +50,8 @@
    "outputs": [],
    "source": [
     "query = '''SELECT f.sample_name, drs_id bam_drs_id, acc\n",
-    "FROM collections.public_datasets.ssd_drs s \n",
-    "join collections.public_datasets.sra_drs_files f on f.sample_name = s.su_submitter_id \n",
+    "FROM collections.public_datasets.onek_genomes_ssd_drs s \n",
+    "join collections.public_datasets.onek_genomes_sra_drs_files f on f.sample_name = s.su_submitter_id \n",
     "where filetype = 'bam' and mapped = 'mapped' \n",
     "and sequencing_type ='exome' and  population = 'JPT' '''\n",
     "\n",
@@ -73,8 +73,8 @@
    "outputs": [],
    "source": [
     "family_query = '''SELECT f.sample_name, relationship, drs_id bam_drs_id, acc\n",
-    "FROM collections.public_datasets.thousand_genomes_meta s \n",
-    "join collections.public_datasets.sra_drs_files f on f.sample_name = s.sample \n",
+    "FROM collections.public_datasets.onek_genomes_thousand_genomes_meta s \n",
+    "join collections.public_datasets.onek_genomes_sra_drs_files f on f.sample_name = s.sample \n",
     "where filetype = 'bam' and mapped = 'mapped' \n",
     "and sequencing_type ='exome' and  family_id = '1447' '''\n",
     "\n",
@@ -118,7 +118,7 @@
    },
    "outputs": [],
    "source": [
-    "schema1 = searchClient.list_table_info('thousand_genomes.onek_genomes.sra_drs_files', verbose=True)"
+    "schema1 = searchClient.list_table_info('collections.public_datasets.onek_genomes_sra_drs_files', verbose=True)"
    ]
   },
   {
@@ -127,7 +127,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "schema2 = searchClient.list_table_info('thousand_genomes.onek_genomes.ssd_drs', verbose=True)"
+    "schema2 = searchClient.list_table_info('collections.public_datasets.onek_genomes_ssd_drs', verbose=True)"
    ]
   },
   {
@@ -160,8 +160,8 @@
    "outputs": [],
    "source": [
     "query = f'''SELECT f.sample_name, drs_id bam_drs_id, acc, filename\n",
-    "FROM collections.public_datasets.ssd_drs s \n",
-    "join collections.public_datasets.sra_drs_files f on f.sample_name = s.su_submitter_id \n",
+    "FROM collections.public_datasets.onek_genomes_ssd_drs s \n",
+    "join collections.public_datasets.onek_genomes_sra_drs_files f on f.sample_name = s.su_submitter_id \n",
     "\n",
     "where filetype = 'bam' and mapped = '{mapping_type}' \n",
     "and sequencing_type ='exome' and  population = '{population_code}'\n",
@@ -201,7 +201,7 @@
    },
    "outputs": [],
    "source": [
-    "searchClient.get_data('collections.public_datasets.ssd_drs', return_type='dataframe')"
+    "searchClient.get_data('collections.public_datasets.onek_genomes_ssd_drs', return_type='dataframe')"
    ]
   },
   {
@@ -287,7 +287,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -301,7 +301,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.6 (default, Oct 18 2022, 12:41:40) \n[Clang 14.0.0 (clang-1400.0.29.202)]"
+   "version": "3.9.6"
   },
   "vscode": {
    "interpreter": {

--- a/sessions/session2/2-3a Finding files.ipynb
+++ b/sessions/session2/2-3a Finding files.ipynb
@@ -38,7 +38,7 @@
    "outputs": [],
    "source": [
     "from fasp.search import DataConnectClient\n",
-    "searchClient = DataConnectClient('https://data-connect-trino-public.prod.dnastack.com/')"
+    "searchClient = DataConnectClient('https://data.publisher.dnastack.com/data-connect/')"
    ]
   },
   {
@@ -50,8 +50,8 @@
    "outputs": [],
    "source": [
     "query = '''SELECT f.sample_name, drs_id bam_drs_id, acc\n",
-    "FROM thousand_genomes.onek_genomes.ssd_drs s \n",
-    "join thousand_genomes.onek_genomes.sra_drs_files f on f.sample_name = s.su_submitter_id \n",
+    "FROM collections.public_datasets.ssd_drs s \n",
+    "join collections.public_datasets.sra_drs_files f on f.sample_name = s.su_submitter_id \n",
     "where filetype = 'bam' and mapped = 'mapped' \n",
     "and sequencing_type ='exome' and  population = 'JPT' '''\n",
     "\n",
@@ -73,8 +73,8 @@
    "outputs": [],
    "source": [
     "family_query = '''SELECT f.sample_name, relationship, drs_id bam_drs_id, acc\n",
-    "FROM thousand_genomes.onek_genomes.thousand_genomes_meta s \n",
-    "join thousand_genomes.onek_genomes.sra_drs_files f on f.sample_name = s.sample \n",
+    "FROM collections.public_datasets.thousand_genomes_meta s \n",
+    "join collections.public_datasets.sra_drs_files f on f.sample_name = s.sample \n",
     "where filetype = 'bam' and mapped = 'mapped' \n",
     "and sequencing_type ='exome' and  family_id = '1447' '''\n",
     "\n",
@@ -160,8 +160,8 @@
    "outputs": [],
    "source": [
     "query = f'''SELECT f.sample_name, drs_id bam_drs_id, acc, filename\n",
-    "FROM thousand_genomes.onek_genomes.ssd_drs s \n",
-    "join thousand_genomes.onek_genomes.sra_drs_files f on f.sample_name = s.su_submitter_id \n",
+    "FROM collections.public_datasets.ssd_drs s \n",
+    "join collections.public_datasets.sra_drs_files f on f.sample_name = s.su_submitter_id \n",
     "\n",
     "where filetype = 'bam' and mapped = '{mapping_type}' \n",
     "and sequencing_type ='exome' and  population = '{population_code}'\n",
@@ -201,7 +201,7 @@
    },
    "outputs": [],
    "source": [
-    "searchClient.get_data('thousand_genomes.onek_genomes.ssd_drs', return_type='dataframe')"
+    "searchClient.get_data('collections.public_datasets.ssd_drs', return_type='dataframe')"
    ]
   },
   {
@@ -287,7 +287,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -301,7 +301,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.9.6 (default, Oct 18 2022, 12:41:40) \n[Clang 14.0.0 (clang-1400.0.29.202)]"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "31f2aee4e71d21fbe5cf8b01ff0e069b9275f58929596ceb00d14d90e3e16cd6"
+   }
   }
  },
  "nbformat": 4,

--- a/sessions/session2/2-3b Finding files via user interface.ipynb
+++ b/sessions/session2/2-3b Finding files via user interface.ipynb
@@ -1,6 +1,7 @@
 {
  "cells": [
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -35,7 +36,7 @@
    "outputs": [],
    "source": [
     "from fasp.search import DataConnectClient\n",
-    "searchClient = DataConnectClient('https://data.publisher.dnastack.com/data-connect/',\n",
+    "searchClient = DataConnectClient('https://publisher-data.publisher.dnastack.com/data-connect/',\n",
     "                                return_type='dataframe'\n",
     "                                ,row_limit=20000)"
    ]
@@ -47,8 +48,8 @@
    "outputs": [],
    "source": [
     "query_all = '''SELECT f.sample_name, drs_id bam_drs_id, acc, population, mapped, sequencing_type\n",
-    "FROM collections.public_datasets.ssd_drs s \n",
-    "join collections.public_datasets.sra_drs_files f on f.sample_name = s.su_submitter_id \n",
+    "FROM collections.public_datasets.onek_genomes_ssd_drs s \n",
+    "join collections.public_datasets.onek_genomes_sra_drs_files f on f.sample_name = s.su_submitter_id \n",
     "where filetype = 'bam'   \n",
     " '''\n",
     "int_df = searchClient.run_query(query_all)\n",
@@ -56,6 +57,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -84,7 +86,7 @@
     "        enumVals[column] = valueList\n",
     "    return enumVals\n",
     "    \n",
-    "info1 = searchClient.list_table_info('thousand_genomes.onek_genomes.ssd_drs').schema\n",
+    "info1 = searchClient.list_table_info('collections.public_datasets.onek_genomes_ssd_drs').schema\n",
     "if info1['description'] == 'Automatically generated schema':\n",
     "    print(\"Data Connect server is not providing custom schema. Cannot continue with this example\")\n",
     "else:\n",
@@ -106,6 +108,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -130,6 +133,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/sessions/session2/2-3b Finding files via user interface.ipynb
+++ b/sessions/session2/2-3b Finding files via user interface.ipynb
@@ -35,7 +35,7 @@
    "outputs": [],
    "source": [
     "from fasp.search import DataConnectClient\n",
-    "searchClient = DataConnectClient('https://data-connect-trino-public.prod.dnastack.com/',\n",
+    "searchClient = DataConnectClient('https://data.publisher.dnastack.com/data-connect/',\n",
     "                                return_type='dataframe'\n",
     "                                ,row_limit=20000)"
    ]
@@ -47,8 +47,8 @@
    "outputs": [],
    "source": [
     "query_all = '''SELECT f.sample_name, drs_id bam_drs_id, acc, population, mapped, sequencing_type\n",
-    "FROM thousand_genomes.onek_genomes.ssd_drs s \n",
-    "join thousand_genomes.onek_genomes.sra_drs_files f on f.sample_name = s.su_submitter_id \n",
+    "FROM collections.public_datasets.ssd_drs s \n",
+    "join collections.public_datasets.sra_drs_files f on f.sample_name = s.su_submitter_id \n",
     "where filetype = 'bam'   \n",
     " '''\n",
     "int_df = searchClient.run_query(query_all)\n",
@@ -149,7 +149,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -163,7 +163,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.9.6 (default, Oct 18 2022, 12:41:40) \n[Clang 14.0.0 (clang-1400.0.29.202)]"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "31f2aee4e71d21fbe5cf8b01ff0e069b9275f58929596ceb00d14d90e3e16cd6"
+   }
   }
  },
  "nbformat": 4,

--- a/sessions/session3/3-1 Putting it all together.ipynb
+++ b/sessions/session3/3-1 Putting it all together.ipynb
@@ -63,8 +63,8 @@
     "\n",
     "query = '''SELECT f.sample_name, drs_id bam_drs_id, acc,\n",
     "population, annotated_sex\n",
-    "FROM collections.public_datasets.ssd_drs s \n",
-    "join collections.public_datasets.sra_drs_files f on f.sample_name = s.su_submitter_id \n",
+    "FROM collections.public_datasets.onek_genomes_ssd_drs s \n",
+    "join collections.public_datasets.onek_genomes_sra_drs_files f on f.sample_name = s.su_submitter_id \n",
     "where filetype = 'bam' and mapped = 'mapped' \n",
     "and sequencing_type ='exome' and  population = 'PUR' LIMIT 3'''\n",
     "\n",
@@ -345,7 +345,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -359,7 +359,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.6 (default, Oct 18 2022, 12:41:40) \n[Clang 14.0.0 (clang-1400.0.29.202)]"
+   "version": "3.9.6"
   },
   "vscode": {
    "interpreter": {

--- a/sessions/session3/3-1 Putting it all together.ipynb
+++ b/sessions/session3/3-1 Putting it all together.ipynb
@@ -59,12 +59,12 @@
    "source": [
     "from fasp.search import DataConnectClient\n",
     "\n",
-    "searchClient = DataConnectClient('https://ga4gh-search-adapter-presto-public.prod.dnastack.com/')\n",
+    "searchClient = DataConnectClient('https://data.publisher.dnastack.com/data-connect/')\n",
     "\n",
     "query = '''SELECT f.sample_name, drs_id bam_drs_id, acc,\n",
     "population, annotated_sex\n",
-    "FROM thousand_genomes.onek_genomes.ssd_drs s \n",
-    "join thousand_genomes.onek_genomes.sra_drs_files f on f.sample_name = s.su_submitter_id \n",
+    "FROM collections.public_datasets.ssd_drs s \n",
+    "join collections.public_datasets.sra_drs_files f on f.sample_name = s.su_submitter_id \n",
     "where filetype = 'bam' and mapped = 'mapped' \n",
     "and sequencing_type ='exome' and  population = 'PUR' LIMIT 3'''\n",
     "\n",
@@ -345,7 +345,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -359,7 +359,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.9.6 (default, Oct 18 2022, 12:41:40) \n[Clang 14.0.0 (clang-1400.0.29.202)]"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "31f2aee4e71d21fbe5cf8b01ff0e069b9275f58929596ceb00d14d90e3e16cd6"
+   }
   }
  },
  "nbformat": 4,

--- a/sessions/session3/3-1 Putting it all together.ipynb
+++ b/sessions/session3/3-1 Putting it all together.ipynb
@@ -59,7 +59,7 @@
    "source": [
     "from fasp.search import DataConnectClient\n",
     "\n",
-    "searchClient = DataConnectClient('https://data.publisher.dnastack.com/data-connect/')\n",
+    "searchClient = DataConnectClient('https://publisher-data.publisher.dnastack.com/data-connect/')\n",
     "\n",
     "query = '''SELECT f.sample_name, drs_id bam_drs_id, acc,\n",
     "population, annotated_sex\n",


### PR DESCRIPTION
This PR is to replace the URL to DNAstack's decommissioned or soon-to-be-decommissioned data connect services.

| Old endpoint | Reason |
| --- | --- |
| `https://data-connect-trino-public.prod.dnastack.com/` | Soon to be decommissioned |
| `https://ga4gh-search-adapter-presto-public.prod.dnastack.com/` | Soon to be decommissioned |

The new endpoint is `https://data.publisher.dnastack.com/data-connect/`.

> NOTE: The tables have been replaced with the same/equivalent one.